### PR TITLE
Add SQLAlchemy user model for auth service

### DIFF
--- a/python/src/auth/Dockerfile
+++ b/python/src/auth/Dockerfile
@@ -8,5 +8,8 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+ENV FLASK_APP=server.py
+
+EXPOSE 8000
 
 CMD ["python", "server.py"]

--- a/python/src/auth/Dockerfile
+++ b/python/src/auth/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "server.py"]

--- a/python/src/auth/README.md
+++ b/python/src/auth/README.md
@@ -1,6 +1,6 @@
 # Auth Service
 
-This service manages authentication using a MySQL database.
+This service manages authentication using a Flask application backed by a MySQL database.
 
 ## Start MySQL with Docker
 
@@ -26,7 +26,7 @@ docker exec -it local-mysql mysql -uroot -ptu_password -e "\
 
 ## Configure the database URL
 
-The service reads `AUTH_DATABASE_URL` for the SQLAlchemy engine.
+The service reads `AUTH_DATABASE_URL` for the Flask SQLAlchemy engine.
 
 Set it in your shell:
 
@@ -48,27 +48,34 @@ From this directory:
 docker build -t auth-service .
 ```
 
-Run the container and provide the database URL:
+Run the container, expose the port and provide the database URL:
 
 ```bash
 docker run --rm \
+  -p 8000:8000 \
   -e AUTH_DATABASE_URL="$AUTH_DATABASE_URL" \
   auth-service
 ```
 
-The service will apply database migrations on startup using Alembic.
+The service will apply database migrations on startup using Flask-Migrate and start a Flask server on port `8000`.
 
 ## Create a new migration (developers)
+
+Set the Flask application for CLI commands:
+
+```bash
+export FLASK_APP=server.py
+```
 
 After modifying models, generate a migration:
 
 ```bash
-alembic revision --autogenerate -m "your message"
+flask db migrate -m "your message"
 ```
 
 Then apply it:
 
 ```bash
-alembic upgrade head
+flask db upgrade
 ```
 

--- a/python/src/auth/README.md
+++ b/python/src/auth/README.md
@@ -56,5 +56,19 @@ docker run --rm \
   auth-service
 ```
 
-The service will initialize the schema on startup.
+The service will apply database migrations on startup using Alembic.
+
+## Create a new migration (developers)
+
+After modifying models, generate a migration:
+
+```bash
+alembic revision --autogenerate -m "your message"
+```
+
+Then apply it:
+
+```bash
+alembic upgrade head
+```
 

--- a/python/src/auth/README.md
+++ b/python/src/auth/README.md
@@ -1,0 +1,60 @@
+# Auth Service
+
+This service manages authentication using a MySQL database.
+
+## Start MySQL with Docker
+
+Run a local MySQL instance and create the initial database:
+
+```bash
+docker run --name local-mysql \
+  -e MYSQL_ROOT_PASSWORD=tu_password \
+  -e MYSQL_DATABASE=auth \
+  -p 3306:3306 \
+  -d mysql:8
+```
+
+Create an application user and grant access:
+
+```bash
+docker exec -it local-mysql mysql -uroot -ptu_password -e "\
+  CREATE USER 'auth_user'@'%' IDENTIFIED BY 'otra_password';\
+  GRANT ALL PRIVILEGES ON auth.* TO 'auth_user'@'%';\
+  FLUSH PRIVILEGES;\
+"
+```
+
+## Configure the database URL
+
+The service reads `AUTH_DATABASE_URL` for the SQLAlchemy engine.
+
+Set it in your shell:
+
+```bash
+export AUTH_DATABASE_URL="mysql+pymysql://auth_user:otra_password@localhost:3306/auth"
+```
+
+Or create a `.env` file (listed in `.gitignore`):
+
+```
+AUTH_DATABASE_URL=mysql+pymysql://auth_user:otra_password@localhost:3306/auth
+```
+
+## Build and run the service
+
+From this directory:
+
+```bash
+docker build -t auth-service .
+```
+
+Run the container and provide the database URL:
+
+```bash
+docker run --rm \
+  -e AUTH_DATABASE_URL="$AUTH_DATABASE_URL" \
+  auth-service
+```
+
+The service will initialize the schema on startup.
+

--- a/python/src/auth/alembic.ini
+++ b/python/src/auth/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = 
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %Y-%m-%d %H:%M:%S

--- a/python/src/auth/migrations/README
+++ b/python/src/auth/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/python/src/auth/migrations/env.py
+++ b/python/src/auth/migrations/env.py
@@ -1,0 +1,46 @@
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from models import Base, DATABASE_URL
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    url = os.getenv("AUTH_DATABASE_URL", DATABASE_URL)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    url = os.getenv("AUTH_DATABASE_URL", DATABASE_URL)
+    config.set_main_option("sqlalchemy.url", url)
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/python/src/auth/migrations/script.py.mako
+++ b/python/src/auth/migrations/script.py.mako
@@ -1,0 +1,18 @@
+"""${message}
+
+Revision ID: ${revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/python/src/auth/migrations/versions/0001_create_user_table.py
+++ b/python/src/auth/migrations/versions/0001_create_user_table.py
@@ -1,0 +1,28 @@
+"""create user table
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-06-08
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("users")

--- a/python/src/auth/models.py
+++ b/python/src/auth/models.py
@@ -1,25 +1,17 @@
 from datetime import datetime
-import os
 
-from sqlalchemy import Column, DateTime, Integer, String, create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
-
-# Database URL, e.g. mysql+pymysql://user:password@localhost/dbname
-DATABASE_URL = os.getenv(
-    "AUTH_DATABASE_URL",
-    "mysql+pymysql://root:password@localhost/auth_db",
-)
-
-engine = create_engine(DATABASE_URL)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base = declarative_base()
+from flask_sqlalchemy import SQLAlchemy
 
 
-class User(Base):
+db = SQLAlchemy()
+
+
+class User(db.Model):
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, index=True)
-    username = Column(String(255), unique=True, nullable=False)
-    email = Column(String(255), unique=True, nullable=False)
-    password_hash = Column(String(255), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(255), unique=True, nullable=False)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+

--- a/python/src/auth/models.py
+++ b/python/src/auth/models.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+import os
+
+from sqlalchemy import Column, DateTime, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+# Database URL, e.g. mysql+pymysql://user:password@localhost/dbname
+DATABASE_URL = os.getenv(
+    "AUTH_DATABASE_URL",
+    "mysql+pymysql://root:password@localhost/auth_db",
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(255), unique=True, nullable=False)
+    email = Column(String(255), unique=True, nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/python/src/auth/requirements.txt
+++ b/python/src/auth/requirements.txt
@@ -1,2 +1,3 @@
 SQLAlchemy>=2.0
 PyMySQL>=1.0
+cryptography

--- a/python/src/auth/requirements.txt
+++ b/python/src/auth/requirements.txt
@@ -1,0 +1,2 @@
+SQLAlchemy>=2.0
+PyMySQL>=1.0

--- a/python/src/auth/requirements.txt
+++ b/python/src/auth/requirements.txt
@@ -1,3 +1,6 @@
+Flask>=2.0
+Flask-SQLAlchemy>=3.0
+Flask-Migrate>=4.0
 SQLAlchemy>=2.0
 PyMySQL>=1.0
 cryptography

--- a/python/src/auth/requirements.txt
+++ b/python/src/auth/requirements.txt
@@ -1,3 +1,4 @@
 SQLAlchemy>=2.0
 PyMySQL>=1.0
 cryptography
+alembic>=1.11

--- a/python/src/auth/server.py
+++ b/python/src/auth/server.py
@@ -1,14 +1,33 @@
 import os
-from alembic import command
-from alembic.config import Config
+
+from flask import Flask
+from flask_migrate import Migrate, upgrade
+
+from models import db, User
 
 
-def run_migrations() -> None:
-    """Apply database migrations."""
-    cfg = Config(os.path.join(os.path.dirname(__file__), "alembic.ini"))
-    command.upgrade(cfg, "head")
+def create_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "AUTH_DATABASE_URL", "mysql+pymysql://root:password@localhost/auth_db"
+    )
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    db.init_app(app)
+    Migrate(app, db)
+
+    @app.route("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+app = create_app()
 
 
 if __name__ == "__main__":
-    run_migrations()
-    print("Database migrated")
+    with app.app_context():
+        upgrade()
+    app.run(host="0.0.0.0", port=8000)
+

--- a/python/src/auth/server.py
+++ b/python/src/auth/server.py
@@ -1,11 +1,14 @@
-from models import Base, engine
+import os
+from alembic import command
+from alembic.config import Config
 
 
-def init_db() -> None:
-    """Initialize the database tables."""
-    Base.metadata.create_all(bind=engine)
+def run_migrations() -> None:
+    """Apply database migrations."""
+    cfg = Config(os.path.join(os.path.dirname(__file__), "alembic.ini"))
+    command.upgrade(cfg, "head")
 
 
 if __name__ == "__main__":
-    init_db()
-    print("Database initialized")
+    run_migrations()
+    print("Database migrated")

--- a/python/src/auth/server.py
+++ b/python/src/auth/server.py
@@ -1,0 +1,11 @@
+from models import Base, engine
+
+
+def init_db() -> None:
+    """Initialize the database tables."""
+    Base.metadata.create_all(bind=engine)
+
+
+if __name__ == "__main__":
+    init_db()
+    print("Database initialized")


### PR DESCRIPTION
## Summary
- add SQLAlchemy-powered `User` model for auth service
- initialize MySQL database tables on server startup
- include SQLAlchemy and PyMySQL in auth service dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4da071c0c8322bbd2ebd11bcc6646